### PR TITLE
fix: custom dropdown options overriden by shot types

### DIFF
--- a/js/details/details-functions.js
+++ b/js/details/details-functions.js
@@ -128,7 +128,6 @@ function saveCurrentSetup() {
                             break;
 
                         case "shot-type":
-                        case "dropdown":
                             // save currently selected option
                             let selectedValue = d
                                 .select("select")


### PR DESCRIPTION
I created a custom dropdown detail with some custom options and pressed save changes. when going back to try and edit this dropdown, the options are the ones set by the default "shot-type" dropdown.

Looking at the code, it seems that the "saveCurrentSetup" function overrides the "details.options" field with the getCurrentShotTypes values for any dropdown, event custom ones.

After removing the "dropdown" case from this function, the issue is fixed. Hopefully it does not harm any other flows.

